### PR TITLE
optimizations on Recipient Commands to avoid syntax Errors

### DIFF
--- a/AegisImplictMail/SmtpSocketClient.cs
+++ b/AegisImplictMail/SmtpSocketClient.cs
@@ -763,8 +763,7 @@ namespace AegisImplicitMail
                     {
                         buf.Append(SmtpCommands.Recipient);
                         buf.Append("<");
-
-                        buf.Append(recipient);
+                        buf.Append(recipient.Address);
                         buf.Append(">");
                         _con.SendCommand(buf.ToString());
                         _con.GetReply(out response, out code);
@@ -777,7 +776,7 @@ namespace AegisImplicitMail
                     {
                         buf.Append(SmtpCommands.Recipient);
                         buf.Append("<");
-                        buf.Append(recipient);
+                        buf.Append(recipient.Address);
                         buf.Append(">");
                         _con.SendCommand(buf.ToString());
                         _con.GetReply(out response, out code);
@@ -791,7 +790,7 @@ namespace AegisImplicitMail
                     {
                         buf.Append(SmtpCommands.Recipient);
                         buf.Append("<");
-                        buf.Append(o);
+                        buf.Append(o.Address);
                         buf.Append(">");
                         _con.SendCommand(buf.ToString());
                         _con.GetReply(out response, out code);

--- a/AegisImplictMail/SmtpSocketClient.cs
+++ b/AegisImplictMail/SmtpSocketClient.cs
@@ -1088,10 +1088,12 @@ namespace AegisImplicitMail
 				_con.SendCommand(buf.ToString());								
 				buf.Length = 0;
 				int num = cs.Read(fbuf, 0, 2048);
-				while(num > 0)
+                char[] bufln = new char[2] { '\r', '\n' };
+                while (num > 0)
 				{					
 					_con.SendData(Encoding.ASCII.GetChars(fbuf, 0, num), 0, num);
-					num = cs.Read(fbuf, 0, 2048);
+                    _con.SendData(bufln, 0, 2);
+                    num = cs.Read(fbuf, 0, 2048);
 				}
 				cs.Close();
 				_con.SendCommand("");

--- a/AegisImplictMail/SmtpSocketClient.cs
+++ b/AegisImplictMail/SmtpSocketClient.cs
@@ -741,12 +741,6 @@ namespace AegisImplicitMail
                     int code;
                     var buf = new StringBuilder {Length = 0};
                     buf.Append(SmtpCommands.Mail);
-                    if (!string.IsNullOrEmpty(MailMessage.From.DisplayName))
-                    {
-                        buf.Append("\"");
-                        buf.Append(MailMessage.From.DisplayName);
-                        buf.Append("\" ");
-                    }
                     buf.Append("<");
                     buf.Append(MailMessage.From.Address);
                     buf.Append(">");                    
@@ -799,6 +793,7 @@ namespace AegisImplicitMail
                         buf.Length = 0;
                     }
                     buf.Length = 0;
+
                     //set headers
                     _con.SendCommand(SmtpCommands.Data);
                     _con.GetReply(out response,out code);
@@ -806,7 +801,7 @@ namespace AegisImplicitMail
                     _con.SendCommand("X-Mailer: AIM.MimeMailer");
                     DateTime today = DateTime.UtcNow;
                     buf.Append(SmtpCommands.Date);
-										buf.Append(today.ToString("r"));
+					buf.Append(today.ToString("r"));
                     _con.SendCommand(buf.ToString());
                     buf.Length = 0;
                     buf.Append(SmtpCommands.From);

--- a/AegisImplictMail/SmtpSocketClient.cs
+++ b/AegisImplictMail/SmtpSocketClient.cs
@@ -841,13 +841,22 @@ namespace AegisImplicitMail
                         }
                         _con.SendCommand(buf.ToString());
                     }
-                    buf.Length = 0;
-                    buf.Append(SmtpCommands.ReplyTo);
-                    buf.Append(MailMessage.From);
-                    _con.SendCommand(buf.ToString());
+                    
+                    if (MailMessage.ReplyToList?.Count > 0)
+                    {
+                        foreach (MailAddress replyToAdr in MailMessage.ReplyToList)
+                        {
+                            buf.Length = 0;
+                            buf.Append(SmtpCommands.ReplyTo);
+                            buf.Append(replyToAdr);
+                            _con.SendCommand(buf.ToString());
+                        }
+                    }
+
                     buf.Length = 0;
                     buf.Append(SmtpCommands.Subject);
-                    buf.Append(GetEncodedSubject());
+                    String encodedSubject = GetEncodedSubject();
+                    buf.Append(encodedSubject);
                     _con.SendCommand(buf.ToString());
                     SendMessageBody(buf);
                     _con.GetReply(out response, out code);
@@ -1100,7 +1109,7 @@ namespace AegisImplicitMail
             else
             {
                 var encodingName = subjectEncoding.BodyName.ToLower();
-                return "=?" + encodingName + "?B?" + TransferEncoder.ToBase64(subjectEncoding.GetBytes(MailMessage.Subject)) + "?=";
+                return "=?" + encodingName + "?B?" + TransferEncoder.ToBase64WithoutLinebrakes(subjectEncoding.GetBytes(MailMessage.Subject)) + "?=";
             }
         }
 

--- a/AegisImplictMail/TransferEncoder.cs
+++ b/AegisImplictMail/TransferEncoder.cs
@@ -121,6 +121,16 @@ namespace AegisImplicitMail
         }
 
         /// <summary>
+        /// Converts a message to Base64.
+        /// </summary>
+        /// <param name="bytes">A byte array to convert.</param>
+        /// <returns>A string containing the converted byte array.</returns>
+        public static string ToBase64WithoutLinebrakes(byte[] bytes)
+        {
+            return Convert.ToBase64String(bytes, Base64FormattingOptions.None);
+        }
+
+        /// <summary>
         /// Converts a message to quoted-printable.
         /// </summary>
         /// <param name="bytes">A byte array to convert.</param>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Getting the Code
 ----------------
 To get a local copy of the current code, clone it using git:
 ```
-$ git clone https://github.com/nilnull/AIM.git
+$ git clone https://github.com/mwidev/AIM.git
 ``` 
 
 Write the code!

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Getting the Code
 ----------------
 To get a local copy of the current code, clone it using git:
 ```
-$ git clone https://github.com/mwidev/AIM.git
+$ git clone https://github.com/nilnull/AIM.git
 ``` 
 
 Write the code!


### PR DESCRIPTION
- Changes for buf.Append(recipient) to buf.Append(recipient.Address)
Because recipient (type of MailAddress) ToString() output like "Display Name" <<mail@domain.com>>
many Mailservers dont accept this anymore
- Displayname is only accepted in headers data
- Bug fixing in subject encoding if subject is longer than 76 characters (Base64 must not have a line break)
- Prevent Error 554 Too long on adding attachment when sending to some Providers