### PR TITLE
Reduce Line Lenght to 998 to comply with RFC 5322 - 2.1.1. Line Lengt

### DIFF
--- a/AegisImplictMail/SmtpSocketClient.cs
+++ b/AegisImplictMail/SmtpSocketClient.cs
@@ -1041,9 +1041,10 @@ namespace AegisImplicitMail
 		/// <param name="type">Attachment type to send.</param>
 		private void SendAttachments(StringBuilder buf, AttachmentLocation type)
 		{
-            
-			//declare mime info for attachment
-			var fbuf = new byte[2048];
+            int bufLen = 998; // to comply with RFC 5322 2.1.1. Line Length Limits
+
+            //declare mime info for attachment
+            var fbuf = new byte[bufLen];
 		    string seperator = type == AttachmentLocation.Attachmed ? "\r\n--#SEPERATOR1#" : "\r\n--#SEPERATOR2#";
 			buf.Length = 0;
 			foreach(MimeAttachment o in MailMessage.Attachments)
@@ -1087,13 +1088,13 @@ namespace AegisImplicitMail
 				buf.Append("\r\n");
 				_con.SendCommand(buf.ToString());								
 				buf.Length = 0;
-				int num = cs.Read(fbuf, 0, 2048);
+				int num = cs.Read(fbuf, 0, bufLen);
                 char[] bufln = new char[2] { '\r', '\n' };
                 while (num > 0)
 				{					
 					_con.SendData(Encoding.ASCII.GetChars(fbuf, 0, num), 0, num);
                     _con.SendData(bufln, 0, 2);
-                    num = cs.Read(fbuf, 0, 2048);
+                    num = cs.Read(fbuf, 0, bufLen);
 				}
 				cs.Close();
 				_con.SendCommand("");


### PR DESCRIPTION
Since mails with a line length of more than 998 characters are not delivered at a few providers, this adjustment in the SendAttachments() method is necessary.